### PR TITLE
97 update payloads in network package

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -588,6 +588,10 @@ where
         &self.team_groups
     }
 
+    pub fn coach_conflicts(&self) -> &[C] {
+        &self.coach_conflicts
+    }
+
     pub fn teams_len(&self) -> usize {
         let mut result = 0;
         for team_group in &self.team_groups {

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -744,7 +744,7 @@ impl CoachConflictLike for CoachConflict {
     }
 
     fn region_id(&self) -> i32 {
-        self.region    
+        self.region
     }
 
     fn unique_id(&self) -> i32 {

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,7 +1,8 @@
 mod pre_schedule_report;
 
 use backend::{
-    FieldLike, PlayableTeamCollection, ProtobufAvailabilityWindow, ScheduledInput, TeamLike,
+    CoachConflictLike, FieldLike, PlayableTeamCollection, ProtobufAvailabilityWindow,
+    ScheduledInput, TeamLike,
 };
 // use communication::{FieldLike, ProtobufAvailabilityWindow, TeamLike};
 use itertools::Itertools;
@@ -11,6 +12,7 @@ pub mod errors;
 use errors::*;
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::ops::Deref;
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -707,12 +709,47 @@ pub struct CopyTimeSlotsInput {
     dst_start: DateTime<Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct CoachConflict {
     id: i32,
     region: i32,
     coach_name: Option<String>,
     teams: Vec<Team>,
+}
+
+#[derive(Clone, PartialEq, PartialOrd)]
+pub struct TeamModelWrapper(Team);
+
+impl Deref for TeamModelWrapper {
+    type Target = Team;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TeamLike for TeamModelWrapper {
+    fn unique_id(&self) -> i32 {
+        self.id
+    }
+}
+
+impl CoachConflictLike for CoachConflict {
+    type Team = TeamModelWrapper;
+    fn teams(&self) -> impl AsRef<[Self::Team]> {
+        self.teams
+            .iter()
+            .cloned()
+            .map(TeamModelWrapper)
+            .collect_vec()
+    }
+
+    fn region_id(&self) -> i32 {
+        self.region    
+    }
+
+    fn unique_id(&self) -> i32 {
+        self.id
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -1784,7 +1821,7 @@ impl Client {
     pub async fn get_scheduled_inputs(
         &self,
     ) -> Result<
-        Vec<ScheduledInput<TeamExtension, TeamCollection, FieldExtension>>,
+        Vec<ScheduledInput<TeamExtension, TeamCollection, FieldExtension, CoachConflict>>,
         GetScheduledInputsError,
     > {
         let mut result = vec![];
@@ -1868,7 +1905,35 @@ impl Client {
                 teams.push(TeamCollection::new(target.groups.clone(), teams_for_target));
             }
 
-            result.push(ScheduledInput::new(i.try_into().unwrap(), teams, fields))
+            let unique_teams = teams
+                .iter()
+                .flat_map(|team_collection| &team_collection.teams)
+                .unique_by(|team_ext| team_ext.team.id)
+                .map(|team_ext| team_ext.team.id);
+
+            let coach_conflicts_to_keep_in_mind = CoachConflictEntity::find()
+                .find_with_related(TeamEntity)
+                .filter(team::Column::Id.is_in(unique_teams))
+                .all(&self.connection)
+                .await
+                .map_err(|e| {
+                    GetScheduledInputsError::DatabaseError(format!("{e} {}:{}", line!(), column!()))
+                })?
+                .into_iter()
+                .map(|(coach_conflict, teams)| CoachConflict {
+                    coach_name: coach_conflict.coach_name,
+                    id: coach_conflict.id,
+                    region: coach_conflict.region,
+                    teams,
+                })
+                .collect_vec();
+
+            result.push(ScheduledInput::new(
+                i.try_into().unwrap(),
+                teams,
+                fields,
+                coach_conflicts_to_keep_in_mind,
+            ))
         }
 
         Ok(result)
@@ -2049,13 +2114,13 @@ impl Client {
             .one(&self.connection)
             .await
             .map_err(|e| CopyTimeSlotsError::DatabaseError(e.to_string()))?
-            .ok_or_else(|| CopyTimeSlotsError::NotFound(input.src_start_id))?;
+            .ok_or(CopyTimeSlotsError::NotFound(input.src_start_id))?;
 
         let end = TimeSlotEntity::find_by_id(input.src_end_id)
             .one(&self.connection)
             .await
             .map_err(|e| CopyTimeSlotsError::DatabaseError(e.to_string()))?
-            .ok_or_else(|| CopyTimeSlotsError::NotFound(input.src_end_id))?;
+            .ok_or(CopyTimeSlotsError::NotFound(input.src_end_id))?;
 
         if start.field_id != end.field_id {
             return Err(CopyTimeSlotsError::FieldMismatch);
@@ -2212,13 +2277,13 @@ impl Client {
             .one(&self.connection)
             .await
             .map_err(|e| DeleteTimeSlotsError::DatabaseError(e.to_string()))?
-            .ok_or_else(|| DeleteTimeSlotsError::NotFound(start_id))?;
+            .ok_or(DeleteTimeSlotsError::NotFound(start_id))?;
 
         let end = TimeSlotEntity::find_by_id(end_id)
             .one(&self.connection)
             .await
             .map_err(|e| DeleteTimeSlotsError::DatabaseError(e.to_string()))?
-            .ok_or_else(|| DeleteTimeSlotsError::NotFound(end_id))?;
+            .ok_or(DeleteTimeSlotsError::NotFound(end_id))?;
 
         if start.field_id != end.field_id {
             return Err(DeleteTimeSlotsError::FieldMismatch);

--- a/desktop/src/bridge.rs
+++ b/desktop/src/bridge.rs
@@ -638,7 +638,7 @@ pub(crate) async fn update_target_reservation_type(
 pub(crate) async fn generate_schedule_payload(
     app: AppHandle,
 ) -> Result<
-    Vec<ScheduledInput<TeamExtension, TeamCollection, FieldExtension>>,
+    Vec<ScheduledInput<TeamExtension, TeamCollection, FieldExtension, CoachConflict>>,
     GetScheduledInputsError,
 > {
     let state = app.state::<SafeAppState>();

--- a/desktop/src/net.rs
+++ b/desktop/src/net.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use backend::{FieldLike, PlayableTeamCollection, ScheduledInput, TeamLike};
+use backend::{CoachConflictLike, FieldLike, PlayableTeamCollection, ScheduledInput, TeamLike};
 use db::{errors::SaveScheduleError, CompiledSchedule};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -20,14 +20,15 @@ pub enum ScheduleRequestError {
     SaveScheduleError(#[from] SaveScheduleError),
 }
 
-pub(crate) async fn send_grpc_schedule_request<T, P, F>(
-    input: impl AsRef<[ScheduledInput<T, P, F>]>,
+pub(crate) async fn send_grpc_schedule_request<T, P, F, C>(
+    input: impl AsRef<[ScheduledInput<T, P, F, C>]>,
     authorization_token: String,
 ) -> Result<CompiledSchedule, ScheduleRequestError>
 where
     T: TeamLike + Clone + Debug + PartialEq + Send,
     P: PlayableTeamCollection<Team = T> + Send,
     F: FieldLike + Clone + Debug + PartialEq + Send,
+    C: CoachConflictLike + Send,
 {
     let scheduler_endpoint = get_scheduler_url();
 
@@ -73,7 +74,7 @@ where
                     )
                     .collect(),
                 unique_id: i as u32,
-                coach_conflicts: todo!("Add in #97 (Update payloads in network package)"),
+                coach_conflicts: todo!(),
             },
         )
         .collect::<Vec<_>>();

--- a/desktop/src/net.rs
+++ b/desktop/src/net.rs
@@ -74,7 +74,30 @@ where
                     )
                     .collect(),
                 unique_id: i as u32,
-                coach_conflicts: todo!(),
+                coach_conflicts: non_message
+                    .coach_conflicts()
+                    .iter()
+                    .map(
+                        |coach_conflict| grpc_server::proto::algo_input::CoachConflict {
+                            region_id: coach_conflict
+                                .region_id()
+                                .try_into()
+                                .expect("coach conflict region id"),
+                            unique_id: coach_conflict
+                                .unique_id()
+                                .try_into()
+                                .expect("coach conflict id"),
+                            teams: coach_conflict
+                                .teams()
+                                .as_ref()
+                                .iter()
+                                .map(|team| grpc_server::proto::algo_input::Team {
+                                    unique_id: team.unique_id().try_into().expect("team id"),
+                                })
+                                .collect(),
+                        },
+                    )
+                    .collect(),
             },
         )
         .collect::<Vec<_>>();


### PR DESCRIPTION
Closes #97 

- Updated protobuf definitions
- Extended: https://github.com/mrodz/fieldz-desktop/blob/ebc83f2893f3ed50303247d1d1a977ab56a02810/db/src/lib.rs#L1784

  ... To select the coach conflicts needed per schedule input payload.
- Modified API bridge between the scheduling server and the client
- New trait: `CoachConflictLike`