### PR TITLE
102 eliminate panics in schedule command

### DIFF
--- a/backend/src/algorithm/v2.rs
+++ b/backend/src/algorithm/v2.rs
@@ -561,7 +561,10 @@ pub(crate) fn schedule_once(state: MCTSState) -> Result<Output> {
         22.. => 1 << 15,
     };
 
-    log::info!("Building MCTSManager manager with capacity {:.3} kb", (approx_table_capacity as f32 * 16. / 1000.));
+    log::info!(
+        "Building MCTSManager manager with capacity {:.3} kb",
+        (approx_table_capacity as f32 * 16. / 1000.)
+    );
 
     let mut mcts = MCTSManager::new(
         state.clone(),

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -574,7 +574,10 @@ where
         }
 
         for coach_conflict in self.coach_conflicts() {
-            result.add_team_collisions(coach_conflict.teams(), Some(&team_index_to_playable_group_index))
+            result.add_team_collisions(
+                coach_conflict.teams(),
+                Some(&team_index_to_playable_group_index),
+            )
         }
 
         Ok(StateTransformer {

--- a/webview/src/lib/index.ts
+++ b/webview/src/lib/index.ts
@@ -327,6 +327,7 @@ export interface UpdateTargetReservationTypeInput {
 export const HAS_DB_RESET_BUTTON: boolean = false;
 export const TIME_SLOT_CREATION_MODAL_ENABLE: boolean = false;
 export const SCHEDULE_CREATION_DELAY: number = 30_000;
+export const SCHEDULE_TIMEOUT_MS: number = 15_000;
 export const SHOW_SCHEDULER_JSON_PAYLOADS: boolean = false;
 export const SHOW_SCHEDULER_URL_WHILE_WAITING: boolean = false;
 


### PR DESCRIPTION
- Remove panics and unwraps in desktop-related scheduling processes
- Set a timeout for how long the user waits after pinging the scheduler before canceling the health probe and showing an error message.
- Code format