### PR TITLE
81 have route display an overview of every input

### DIFF
--- a/desktop/src/bridge.rs
+++ b/desktop/src/bridge.rs
@@ -1,6 +1,6 @@
 use backend::ScheduledInput;
 use base64::Engine;
-use db::{errors::*, CoachConflictTeamInput, CreateCoachConflictInput};
+use db::{errors::*, CoachConflictTeamInput, CreateCoachConflictInput, RegionMetadata};
 use db::{
     CoachConflict, CopyTimeSlotsInput, CreateFieldInput, CreateRegionInput,
     CreateReservationTypeInput, CreateTeamInput, CreateTimeSlotInput, EditRegionInput,
@@ -903,4 +903,16 @@ pub(crate) async fn get_coach_conflicts(
         .ok_or(CoachConflictError::NoDatabase)?;
 
     client.get_coach_conflicts(region_id).await
+}
+
+#[tauri::command]
+pub(crate) async fn get_region_metadata(
+    app: AppHandle,
+    region_id: i32,
+) -> Result<RegionMetadata, LoadRegionError> {
+    let state = app.state::<SafeAppState>();
+    let lock = state.0.lock().await;
+    let client = lock.database.as_ref().ok_or(LoadRegionError::NoDatabase)?;
+
+    client.get_region_metadata(region_id).await
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -136,6 +136,7 @@ fn main() -> Result<()> {
                 coaching_conflict_team_op,
                 coaching_conflict_rename,
                 get_coach_conflicts,
+                get_region_metadata,
             ])
             .run(tauri::generate_context!())
             .context("error while running tauri application")

--- a/webview/src/lib/index.ts
+++ b/webview/src/lib/index.ts
@@ -180,11 +180,11 @@ export interface TargetExtension {
 
 export type RegionalUnionU64 =
 	| {
-		Interregional: number;
-	}
+			Interregional: number;
+	  }
 	| {
-		Regional: [number, number][];
-	};
+			Regional: [number, number][];
+	  };
 
 export interface DuplicateEntry {
 	team_groups: TeamGroup[];

--- a/webview/src/lib/index.ts
+++ b/webview/src/lib/index.ts
@@ -180,11 +180,11 @@ export interface TargetExtension {
 
 export type RegionalUnionU64 =
 	| {
-			Interregional: number;
-	  }
+		Interregional: number;
+	}
 	| {
-			Regional: [number, number][];
-	  };
+		Regional: [number, number][];
+	};
 
 export interface DuplicateEntry {
 	team_groups: TeamGroup[];
@@ -393,4 +393,11 @@ export interface CoachingConflict {
 	teams: Team[];
 	coach_name?: string;
 	region: number;
+}
+
+export interface RegionMetadata {
+	region_id: number;
+	team_count: number;
+	field_count: number;
+	time_slot_count: number;
 }

--- a/webview/src/lib/modals/RegionCreate.svelte
+++ b/webview/src/lib/modals/RegionCreate.svelte
@@ -32,11 +32,23 @@
 			if (typeof e === 'object' && 'ValidationError' in e) {
 				const error = e['ValidationError'];
 
-				if (error === 'EmptyName') {
-					regionNameError = 'Region name cannot be empty';
-				} else if (typeof error === 'object' && 'NameTooLong' in error) {
-					const nameTooLong = error['NameTooLong'];
-					regionNameError = `Region name is ${nameTooLong?.len} characters which is larger than the max, 64`;
+				if (error === null) {
+					dialog.message('Error is null', {
+						title: 'Error',
+						type: 'error'
+					});
+				} else if (typeof error === 'object' && 'Name' in error) {
+					if (error.Name === 'EmptyName') {
+						regionNameError = 'Region name cannot be empty';
+					} else if (typeof error.Name === 'object' && 'NameTooLong' in error.Name) {
+						const nameTooLong = error.Name['NameTooLong'];
+						regionNameError = `Region name is ${nameTooLong?.len} characters which is larger than the max, 64`;
+					} else {
+						dialog.message(JSON.stringify(e), {
+							title: 'Error',
+							type: 'error'
+						});
+					}
 				} else {
 					// unknown validation error!
 					dialog.message(JSON.stringify(e), {

--- a/webview/src/routes/+layout.svelte
+++ b/webview/src/routes/+layout.svelte
@@ -152,9 +152,8 @@
 		placement: 'bottom',
 		state(event) {
 			if (event.state) popupCard.style.zIndex = '100000';
-		},
+		}
 	} satisfies PopupSettings;
-
 </script>
 
 <Toast />
@@ -179,6 +178,17 @@
 		{/await}
 	</svelte:fragment>
 	<svelte:fragment slot="header">
+		<!--
+			We need to create a unique stacking context for the z-index in the popups to work.
+			One way to create a stacking context is by specifying a z-index on a parent element.
+			We need to select the header inserted by the `AppShell` as this is the first level
+			we can create a rival stacking context.
+		-->
+		<style>
+			header#shell-header {
+				z-index: 500;
+			}
+		</style>
 		<AppBar>
 			<svelte:fragment slot="lead">
 				<LightSwitch />
@@ -227,7 +237,11 @@
 						{/if}
 					</div>
 
-					<div class="card variant-filled-primary w-96 p-4" data-popup="avatarClick" bind:this={popupCard}>
+					<div
+						class="card variant-filled-primary z-[500] w-96 p-4"
+						data-popup="avatarClick"
+						bind:this={popupCard}
+					>
 						<p>
 							Hi, {$authStore.user.displayName ?? 'Guest'}.
 						</p>

--- a/webview/src/routes/+layout.svelte
+++ b/webview/src/routes/+layout.svelte
@@ -144,11 +144,17 @@
 		}
 	}
 
+	let popupCard: HTMLDivElement;
+
 	const avatarClick = {
 		event: 'click',
 		target: 'avatarClick',
-		placement: 'bottom'
+		placement: 'bottom',
+		state(event) {
+			if (event.state) popupCard.style.zIndex = '100000';
+		},
 	} satisfies PopupSettings;
+
 </script>
 
 <Toast />
@@ -196,7 +202,7 @@
 
 			<svelte:fragment slot="trail">
 				{#if $authStore.user !== undefined}
-					<div use:popup={avatarClick}>
+					<div use:popup={avatarClick} class="z-[500]">
 						{#if $authStore.user.photoURL}
 							<Avatar
 								cursor="cursor-pointer"
@@ -221,7 +227,7 @@
 						{/if}
 					</div>
 
-					<div class="card variant-filled-primary w-96 p-4" data-popup="avatarClick">
+					<div class="card variant-filled-primary w-96 p-4" data-popup="avatarClick" bind:this={popupCard}>
 						<p>
 							Hi, {$authStore.user.displayName ?? 'Guest'}.
 						</p>

--- a/webview/src/routes/+page.svelte
+++ b/webview/src/routes/+page.svelte
@@ -2,37 +2,48 @@
 	import { slide } from 'svelte/transition';
 	import ScheduleList from './schedules/ScheduleList.svelte';
 	import Groups from './groups/Groups.svelte';
+	import FieldTypes from './field-types/FieldTypes.svelte';
+	import RegionList from './regions/RegionList.svelte';
+	import CreateRegionButton from './regions/CreateRegionButton.svelte';
+
+	let regionList: RegionList;
 </script>
 
-<main in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }} class="p-4">
-	<h1 class="h1 mt-2">Fieldz</h1>
+<main in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }}>
+	<h1 class="h1 m-8">Home</h1>
 
-	<hr class="hr my-5" />
-
-	<section class="card sticky my-4 p-4">
+	<section class="card sticky top-0 my-4 rounded-none border-none px-8 py-4 shadow-none ring-0">
 		<header class="h4 mb-2">Jump To</header>
 		<div class="flex flex-row gap-4">
+			<a href="#groups" class="chip variant-filled-primary">Groups</a>
+			<a href="#sizes" class="chip variant-filled-primary">Field Sizes</a>
+			<a href="#regions" class="chip variant-filled-primary">Regions</a>
 			<a href="#schedules" class="chip variant-filled-primary">Schedules</a>
-			<a href="#schedules" class="chip variant-filled-primary">Groups</a>
 		</div>
 	</section>
 
-	<hr class="hr my-5" />
+	<div class="p-4 [&>section]:my-8 [&>section]:p-8">
+		<section id="groups">
+			<h2 class="h2">Team Groupings</h2>
+			<Groups />
+		</section>
 
-	<section id="groups" class="my-8">
-		<h2 class="h2">Team Groupings</h2>
-		<Groups />
-	</section>
+		<section id="sizes">
+			<h2 class="h2">Field Types/Sizes</h2>
+			<FieldTypes />
+		</section>
 
-	<section id="groups" class="my-8">
-		<h2 class="h2">Field Types</h2>
-		
-	</section>
+		<section id="regions">
+			<h2 class="h2">Regions</h2>
+			<RegionList bind:this={regionList} />
+			<CreateRegionButton {regionList} />
+		</section>
 
-	<section id="schedules" class="my-8">
-		<h2 class="h2">Schedules</h2>
-		<ScheduleList src="home" />
-	</section>
+		<section id="schedules">
+			<h2 class="h2">Schedules</h2>
+			<ScheduleList src="home" />
+		</section>
 
-	
+
+	</div>
 </main>

--- a/webview/src/routes/+page.svelte
+++ b/webview/src/routes/+page.svelte
@@ -1,11 +1,38 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
 	import ScheduleList from './schedules/ScheduleList.svelte';
+	import Groups from './groups/Groups.svelte';
 </script>
 
 <main in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }} class="p-4">
 	<h1 class="h1 mt-2">Fieldz</h1>
-	<section>
+
+	<hr class="hr my-5" />
+
+	<section class="card sticky my-4 p-4">
+		<header class="h4 mb-2">Jump To</header>
+		<div class="flex flex-row gap-4">
+			<a href="#schedules" class="chip variant-filled-primary">Schedules</a>
+			<a href="#schedules" class="chip variant-filled-primary">Groups</a>
+		</div>
+	</section>
+
+	<hr class="hr my-5" />
+
+	<section id="groups" class="my-8">
+		<h2 class="h2">Team Groupings</h2>
+		<Groups />
+	</section>
+
+	<section id="groups" class="my-8">
+		<h2 class="h2">Field Types</h2>
+		
+	</section>
+
+	<section id="schedules" class="my-8">
+		<h2 class="h2">Schedules</h2>
 		<ScheduleList src="home" />
 	</section>
+
+	
 </main>

--- a/webview/src/routes/+page.svelte
+++ b/webview/src/routes/+page.svelte
@@ -9,10 +9,10 @@
 	let regionList: RegionList;
 </script>
 
-<main in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }}>
+<main id="fieldz-home" in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }}>
 	<h1 class="h1 m-8">Home</h1>
 
-	<section class="card sticky top-0 my-4 rounded-none border-none px-8 py-4 shadow-none ring-0">
+	<section class="card sticky top-0 my-4 rounded-none border-none px-8 py-4 shadow-none ring-0 z-20">
 		<header class="h4 mb-2">Jump To</header>
 		<div class="flex flex-row gap-4">
 			<a href="#groups" class="chip variant-filled-primary">Groups</a>
@@ -22,9 +22,9 @@
 		</div>
 	</section>
 
-	<div class="p-4 [&>section]:my-8 [&>section]:p-8">
+	<div class="p-4">
 		<section id="groups">
-			<h2 class="h2">Team Groupings</h2>
+			<h2 class="h2 mb-16">Team Groupings</h2>
 			<Groups />
 		</section>
 
@@ -34,16 +34,60 @@
 		</section>
 
 		<section id="regions">
-			<h2 class="h2">Regions</h2>
+			<h2 class="h2 mb-8">Regions</h2>
 			<RegionList bind:this={regionList} />
 			<CreateRegionButton {regionList} />
 		</section>
 
 		<section id="schedules">
-			<h2 class="h2">Schedules</h2>
+			<h2 class="h2 mb-8">Schedules</h2>
 			<ScheduleList src="home" />
 		</section>
-
-
 	</div>
 </main>
+
+<style>
+	#fieldz-home {
+		counter-reset: section-counter;
+	}
+
+	section {
+		margin: 2rem 0;
+		padding: 2rem;
+	}
+
+	section > h2 {
+		position: relative;
+	}
+
+	section > h2::after {
+		counter-increment: section-counter;
+		content: counter(section-counter);
+		position: absolute;
+		right: 40px;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 50px;
+		height: 50px;
+		line-height: 50px;
+		border-radius: 50%;
+		text-align: center;
+		font-weight: bold;
+	}
+
+	section#groups > h2::after {
+		background-color: #db4d34;
+	}
+
+	section#sizes > h2::after {
+		background-color: #f5a208;
+	}
+
+	section#regions > h2::after {
+		background-color: #26af5d;
+	}
+
+	section#schedules > h2::after {
+		background-color: #08c6f5;
+	}
+</style>

--- a/webview/src/routes/+page.svelte
+++ b/webview/src/routes/+page.svelte
@@ -12,13 +12,15 @@
 <main id="fieldz-home" in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }}>
 	<h1 class="h1 m-8">Home</h1>
 
-	<section class="card sticky top-0 my-4 rounded-none border-none px-8 py-4 shadow-none ring-0 z-20">
+	<section
+		class="card sticky top-0 z-20 my-4 rounded-none border-none px-8 py-4 shadow-none ring-0"
+	>
 		<header class="h4 mb-2">Jump To</header>
 		<div class="flex flex-row gap-4">
-			<a href="#groups" class="chip variant-filled-primary">Groups</a>
-			<a href="#sizes" class="chip variant-filled-primary">Field Sizes</a>
-			<a href="#regions" class="chip variant-filled-primary">Regions</a>
-			<a href="#schedules" class="chip variant-filled-primary">Schedules</a>
+			<a href="#groups" class="variant-filled-primary chip">Groups</a>
+			<a href="#sizes" class="variant-filled-primary chip">Field Sizes</a>
+			<a href="#regions" class="variant-filled-primary chip">Regions</a>
+			<a href="#schedules" class="variant-filled-primary chip">Schedules</a>
 		</div>
 	</section>
 

--- a/webview/src/routes/field-types/+page.svelte
+++ b/webview/src/routes/field-types/+page.svelte
@@ -1,94 +1,6 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
-	import { onMount } from 'svelte';
-	import ReservationTypeComponent from './ReservationType.svelte';
-	import { type ReservationType, type CreateReservationTypeInput, randomCalendarColor } from '$lib';
-	import { invoke, dialog } from '@tauri-apps/api';
-	import { ProgressRadial } from '@skeletonlabs/skeleton';
-
-	let reservations: ReservationType[] | undefined;
-
-	onMount(async () => {
-		try {
-			reservations = await invoke<ReservationType[]>('get_reservation_types');
-		} catch (e) {
-			dialog.message(JSON.stringify(e), {
-				title: 'Could not load reservation types',
-				type: 'error'
-			});
-		}
-	});
-
-	async function newType() {
-		try {
-			let name = 'New Reservation Type';
-
-			if (reservations?.length ?? 0 !== 0) {
-				const last = reservations?.findLast((reservationType) =>
-					/^New Reservation Type(\s\(\d+\))?$/.test(reservationType.name)
-				);
-
-				if (last !== undefined) {
-					if (last.name === name) {
-						name += ' (1)';
-					} else {
-						const lastNumberString = last.name.slice(22, last.name.length - 1);
-						const lastNumber = Number(lastNumberString);
-						name += ` (${lastNumber + 1})`;
-					}
-				}
-			}
-
-			const input = {
-				name,
-				color: randomCalendarColor()
-			} satisfies CreateReservationTypeInput;
-
-			const type = await invoke<ReservationType>('create_reservation_type', { input });
-
-			reservations?.push(type);
-			reservations = reservations;
-		} catch (e) {
-			dialog.message(JSON.stringify(e), {
-				title: 'Could not create reservation type',
-				type: 'error'
-			});
-		}
-	}
-
-	async function deleteType(reservationType: ReservationType, index: number) {
-		try {
-			await invoke<ReservationType>('delete_reservation_type', { id: reservationType.id });
-
-			reservations?.splice(index, 1);
-			reservations = reservations;
-		} catch (e) {
-			dialog.message(JSON.stringify(e), {
-				title: 'Could not delete reservation type',
-				type: 'error'
-			});
-		}
-	}
-
-	async function updateType(
-		reservationType: ReservationType,
-		options?: {
-			nameOnLoad: string;
-		}
-	) {
-		try {
-			if (reservationType.name.length === 0) {
-				reservationType.name = options?.nameOnLoad ?? 'New Reservation Type (?)';
-			}
-
-			await invoke<ReservationType>('update_reservation_type', { reservationType });
-		} catch (e) {
-			dialog.message(JSON.stringify(e), {
-				title: 'Could not save changes to reservation type',
-				type: 'error'
-			});
-		}
-	}
+	import FieldTypes from './FieldTypes.svelte';
 </script>
 
 <main in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }}>
@@ -103,29 +15,5 @@
 		</p>
 	</section>
 
-	<section class="m-4">
-		{#if reservations === undefined}
-			<ProgressRadial />
-		{:else if reservations.length !== 0}
-			<div class="grid grid-cols-1 gap-2 lg:grid-cols-2">
-				{#each reservations as reservation, i}
-					<ReservationTypeComponent
-						{reservation}
-						on:delete={(e) => deleteType(e.detail, i)}
-						on:debouncedUpdate={(e) => updateType(e.detail.reservation, e.detail.options)}
-					/>
-				{/each}
-			</div>
-
-			<hr class="hr my-5" />
-
-			<button class="variant-filled btn" on:click={() => newType()}>+ New Type</button>
-		{:else}
-			<div class="card m-4 p-4 text-center">
-				<i class="my-4 block">You haven't created any reservation types yet</i>
-				<hr class="hr my-5" />
-				<button class="variant-filled btn" on:click={() => newType()}>+ New Type</button>
-			</div>
-		{/if}
-	</section>
+	<FieldTypes />
 </main>

--- a/webview/src/routes/field-types/+page.svelte
+++ b/webview/src/routes/field-types/+page.svelte
@@ -127,6 +127,5 @@
 				<button class="variant-filled btn" on:click={() => newType()}>+ New Type</button>
 			</div>
 		{/if}
-		<!-- <ReservationTypeComponent reservation={{ id: 1, name: 'small field', color: '#ffffff' }} /> -->
 	</section>
 </main>

--- a/webview/src/routes/field-types/FieldTypes.svelte
+++ b/webview/src/routes/field-types/FieldTypes.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { dialog, invoke } from "@tauri-apps/api";
-	import { default as ReservationTypeComponent } from "./ReservationType.svelte";
-	import { onMount } from "svelte";
-	import { randomCalendarColor, type CreateReservationTypeInput, type ReservationType } from "$lib";
-	import { ProgressRadial } from "@skeletonlabs/skeleton";
+	import { dialog, invoke } from '@tauri-apps/api';
+	import { default as ReservationTypeComponent } from './ReservationType.svelte';
+	import { onMount } from 'svelte';
+	import { randomCalendarColor, type CreateReservationTypeInput, type ReservationType } from '$lib';
+	import { ProgressRadial } from '@skeletonlabs/skeleton';
 
 	let reservations: ReservationType[] | undefined;
 
@@ -94,7 +94,7 @@
 	{#if reservations === undefined}
 		<ProgressRadial />
 	{:else if reservations.length !== 0}
-		<div class="w-full xl:w-4/5 grid grid-cols-1 gap-10 lg:grid-cols-2 mb-4">
+		<div class="mb-4 grid w-full grid-cols-1 gap-10 lg:grid-cols-2 xl:w-4/5">
 			{#each reservations as reservation, i}
 				<ReservationTypeComponent
 					{reservation}
@@ -104,11 +104,15 @@
 			{/each}
 		</div>
 
-		<button class="variant-filled btn mx-auto" on:click={() => newType()}>Create Reservation Type</button>
+		<button class="variant-filled btn mx-auto" on:click={() => newType()}
+			>Create Reservation Type</button
+		>
 	{:else}
 		<div class="card m-4 p-4 text-center">
 			<i class="my-4 block">You haven't created any reservation types yet</i>
-			<button class="variant-filled btn mx-auto" on:click={() => newType()}>Create Reservation Type</button>
+			<button class="variant-filled btn mx-auto" on:click={() => newType()}
+				>Create Reservation Type</button
+			>
 		</div>
 	{/if}
 </section>

--- a/webview/src/routes/field-types/FieldTypes.svelte
+++ b/webview/src/routes/field-types/FieldTypes.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { dialog, invoke } from "@tauri-apps/api";
+	import { default as ReservationTypeComponent } from "./ReservationType.svelte";
+	import { onMount } from "svelte";
+	import { randomCalendarColor, type CreateReservationTypeInput, type ReservationType } from "$lib";
+	import { ProgressRadial } from "@skeletonlabs/skeleton";
+
+	let reservations: ReservationType[] | undefined;
+
+	onMount(async () => {
+		try {
+			reservations = await invoke<ReservationType[]>('get_reservation_types');
+		} catch (e) {
+			dialog.message(JSON.stringify(e), {
+				title: 'Could not load reservation types',
+				type: 'error'
+			});
+		}
+	});
+
+	async function newType() {
+		try {
+			let name = 'New Reservation Type';
+
+			if (reservations?.length ?? 0 !== 0) {
+				const last = reservations?.findLast((reservationType) =>
+					/^New Reservation Type(\s\(\d+\))?$/.test(reservationType.name)
+				);
+
+				if (last !== undefined) {
+					if (last.name === name) {
+						name += ' (1)';
+					} else {
+						const lastNumberString = last.name.slice(22, last.name.length - 1);
+						const lastNumber = Number(lastNumberString);
+						name += ` (${lastNumber + 1})`;
+					}
+				}
+			}
+
+			const input = {
+				name,
+				color: randomCalendarColor()
+			} satisfies CreateReservationTypeInput;
+
+			const type = await invoke<ReservationType>('create_reservation_type', { input });
+
+			reservations?.push(type);
+			reservations = reservations;
+		} catch (e) {
+			dialog.message(JSON.stringify(e), {
+				title: 'Could not create reservation type',
+				type: 'error'
+			});
+		}
+	}
+
+	async function deleteType(reservationType: ReservationType, index: number) {
+		try {
+			await invoke<ReservationType>('delete_reservation_type', { id: reservationType.id });
+
+			reservations?.splice(index, 1);
+			reservations = reservations;
+		} catch (e) {
+			dialog.message(JSON.stringify(e), {
+				title: 'Could not delete reservation type',
+				type: 'error'
+			});
+		}
+	}
+
+	async function updateType(
+		reservationType: ReservationType,
+		options?: {
+			nameOnLoad: string;
+		}
+	) {
+		try {
+			if (reservationType.name.length === 0) {
+				reservationType.name = options?.nameOnLoad ?? 'New Reservation Type (?)';
+			}
+
+			await invoke<ReservationType>('update_reservation_type', { reservationType });
+		} catch (e) {
+			dialog.message(JSON.stringify(e), {
+				title: 'Could not save changes to reservation type',
+				type: 'error'
+			});
+		}
+	}
+</script>
+
+<section class="m-4 flex flex-col items-center">
+	{#if reservations === undefined}
+		<ProgressRadial />
+	{:else if reservations.length !== 0}
+		<div class="w-full xl:w-4/5 grid grid-cols-1 gap-10 lg:grid-cols-2 mb-4">
+			{#each reservations as reservation, i}
+				<ReservationTypeComponent
+					{reservation}
+					on:delete={(e) => deleteType(e.detail, i)}
+					on:debouncedUpdate={(e) => updateType(e.detail.reservation, e.detail.options)}
+				/>
+			{/each}
+		</div>
+
+		<button class="variant-filled btn mx-auto" on:click={() => newType()}>Create Reservation Type</button>
+	{:else}
+		<div class="card m-4 p-4 text-center">
+			<i class="my-4 block">You haven't created any reservation types yet</i>
+			<button class="variant-filled btn mx-auto" on:click={() => newType()}>Create Reservation Type</button>
+		</div>
+	{/if}
+</section>

--- a/webview/src/routes/groups/+page.svelte
+++ b/webview/src/routes/groups/+page.svelte
@@ -3,6 +3,27 @@
 	import Groups from './Groups.svelte';
 </script>
 
-<main in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }}>
+<main class="p-4" in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }}>
+	<h2 class="h2">Groups</h2>
+
+	<div class="[&>*]:my-4">
+		<p>
+			Here is where you create labels you'll use to group teams
+			<strong>across regions</strong>. Teams that you create in any region can have many grouping
+			labels.
+		</p>
+		<p>
+			Try to make labels as generic as possible. Once you've inputted all of your data, you can
+			create scheduling targets to have specific groups play each other.
+		</p>
+		<p>Some use cases might be:</p>
+		<ul class="list">
+			<li>&bull; Age Groups (u8, u10, u12, etc)</li>
+			<li>&bull; Boys/Girls</li>
+			<li>&bull; Extras or All Stars</li>
+			<li>&bull; Tournament Brackets</li>
+		</ul>
+	</div>
+
 	<Groups />
 </main>

--- a/webview/src/routes/groups/Groups.svelte
+++ b/webview/src/routes/groups/Groups.svelte
@@ -67,28 +67,7 @@
 	}
 </script>
 
-<section class="p-4">
-	<h2 class="h2">Groups</h2>
-
-	<div class="[&>*]:my-4">
-		<p>
-			Here is where you create labels you'll use to group teams
-			<strong>across regions</strong>. Teams that you create in any region can have many grouping
-			labels.
-		</p>
-		<p>
-			Try to make labels as generic as possible. Once you've inputted all of your data, you can
-			create scheduling targets to have specific groups play each other.
-		</p>
-		<p>Some use cases might be:</p>
-		<ul class="list">
-			<li>&bull; Age Groups (u8, u10, u12, etc)</li>
-			<li>&bull; Boys/Girls</li>
-			<li>&bull; Extras or All Stars</li>
-			<li>&bull; Tournament Brackets</li>
-		</ul>
-	</div>
-
+<section>
 	<InputChip
 		bind:value={groupsFrontend}
 		on:add={(customEvent) => {

--- a/webview/src/routes/groups/Groups.svelte
+++ b/webview/src/routes/groups/Groups.svelte
@@ -8,7 +8,7 @@
 	let toastStore = getToastStore();
 
 	let groups: TeamGroup[] = [];
-	$: groupsFrontend = groups.map((group) => `${group.name} (${group.usages})`);
+	$: groupsFrontend = groups.map((group) => `${group.name} (${group.usages} teams)`);
 
 	onMount(async () => {
 		try {

--- a/webview/src/routes/login/+page.svelte
+++ b/webview/src/routes/login/+page.svelte
@@ -15,7 +15,6 @@
 	import MicrosoftIcon from './MicrosoftIcon.svelte';
 	import { type } from '@tauri-apps/api/os';
 	import { githubLogin, googleLogin, twitterLogin } from '$lib/auth';
-	import authStore from '$lib/authStore';
 
 	const queryParams = new URLSearchParams(window.location.search);
 	const next = queryParams.get('next') ?? '/';

--- a/webview/src/routes/region/+page.svelte
+++ b/webview/src/routes/region/+page.svelte
@@ -557,7 +557,7 @@
 									<td role="gridcell" aria-colindex="1" tabindex="-1">
 										{field.name}
 									</td>
-									<td role="gridcell" width="1%" aria-colindex="3" tabindex="-1">
+									<td role="gridcell" width="1%" aria-colindex="2" tabindex="-1">
 										<a
 											class="variant-filled btn mx-auto block"
 											href={`/reservations?fieldId=${field.id}`}

--- a/webview/src/routes/regions/+page.svelte
+++ b/webview/src/routes/regions/+page.svelte
@@ -1,34 +1,15 @@
 <script lang="ts">
-	import { type Region } from '$lib';
 	import { slide } from 'svelte/transition';
 	import RegionList from './RegionList.svelte';
-	import { getModalStore, getToastStore } from '@skeletonlabs/skeleton';
-
-	const toastStore = getToastStore();
-	const modalStore = getModalStore();
+	import CreateRegionButton from './CreateRegionButton.svelte';
 
 	let regionList: RegionList;
-
-	function createRegion() {
-		modalStore.trigger({
-			type: 'component',
-			component: 'regionCreate',
-			meta: {
-				onCreate(region: Region) {
-					toastStore.trigger({
-						message: `Created new region: "${region.title}"`,
-						background: 'variant-filled-success'
-					});
-					regionList.addRegionToFrontend(region);
-				}
-			}
-		});
-	}
 </script>
 
 <main in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }} class="p-4">
 	<h2 class="h2">Regions</h2>
 
 	<RegionList bind:this={regionList} />
-	<button class="variant-filled btn mx-auto block" on:click={createRegion}> Create Region </button>
+
+	<CreateRegionButton {regionList} />
 </main>

--- a/webview/src/routes/regions/CreateRegionButton.svelte
+++ b/webview/src/routes/regions/CreateRegionButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import type { Region } from "$lib";
-	import { getModalStore, getToastStore } from "@skeletonlabs/skeleton";
-	import RegionList from "./RegionList.svelte";
+	import type { Region } from '$lib';
+	import { getModalStore, getToastStore } from '@skeletonlabs/skeleton';
+	import RegionList from './RegionList.svelte';
 
 	export let regionList: RegionList;
 
@@ -18,7 +18,15 @@
 						message: `Created new region: "${region.title}"`,
 						background: 'variant-filled-success'
 					});
-					regionList.addRegionToFrontend(region);
+					regionList.addRegionToFrontend([
+						region,
+						Promise.resolve({
+							region_id: region.id,
+							field_count: 0,
+							team_count: 0,
+							time_slot_count: 0
+						})
+					]);
 				}
 			}
 		});

--- a/webview/src/routes/regions/CreateRegionButton.svelte
+++ b/webview/src/routes/regions/CreateRegionButton.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { Region } from "$lib";
+	import { getModalStore, getToastStore } from "@skeletonlabs/skeleton";
+	import RegionList from "./RegionList.svelte";
+
+	export let regionList: RegionList;
+
+	const toastStore = getToastStore();
+	const modalStore = getModalStore();
+
+	function createRegion() {
+		modalStore.trigger({
+			type: 'component',
+			component: 'regionCreate',
+			meta: {
+				onCreate(region: Region) {
+					toastStore.trigger({
+						message: `Created new region: "${region.title}"`,
+						background: 'variant-filled-success'
+					});
+					regionList.addRegionToFrontend(region);
+				}
+			}
+		});
+	}
+</script>
+
+<button class="variant-filled btn mx-auto block" on:click={createRegion}> Create Region </button>

--- a/webview/src/routes/schedules/ScheduleCard.svelte
+++ b/webview/src/routes/schedules/ScheduleCard.svelte
@@ -26,7 +26,9 @@
 		minute: 'numeric'
 	};
 
-	const target = `popupClick-schedule-${schedule.id}-${schedule.name}-${src}`;
+	const escapeScheduleName = (name: string) => name.replace(/[^a-zA-Z0-9-_:.]/g, '_');
+
+	const target = `popupClick-schedule-${schedule.id}-${escapeScheduleName(schedule.name)}-${src}-${schedule.created}`;
 
 	const popupClick: PopupSettings = {
 		event: 'click',

--- a/webview/src/routes/schedules/ScheduleList.svelte
+++ b/webview/src/routes/schedules/ScheduleList.svelte
@@ -37,38 +37,36 @@
 	}
 </script>
 
-<div class="relative grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 min-[2200px]:grid-cols-4">
-	{#if schedules === undefined}
+{#if schedules === undefined}
+	<ProgressRadial />
+{:else}
+	{#await schedules}
 		<ProgressRadial />
-	{:else}
-		{#await schedules}
-			<ProgressRadial />
-		{:then schedules}
-			{#each schedules as schedule, i}
-				<ScheduleCard {src} on:delete={() => cardDeletion(i)} on:update={cardUpdate} {schedule} />
-			{:else}
-				<div class="mt-4 absolute left-1/2 -translate-x-1/2">
-					You haven't generated a schedule yet.
-					<!-- This has to go here because of position: absolute trickery -->
-					<div class="my-auto mt-6 flex flex-col">
-						<a
-							href="/scheduler"
-							class="variant-filled btn-icon mx-auto block flex h-[75px] w-[75px]"
-						>
-							+
-						</a>
-						<span class="mx-auto mt-2 block">Create Schedule</span>
-					</div>
-				</div>
-			{/each}
-			{#if schedules.length > 0}
-				<div class="my-auto ml-10 flex flex-col">
+	{:then schedules}
+		{#if schedules.length !== 0}
+			<div
+				class="relative grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 min-[2200px]:grid-cols-4"
+			>
+				{#each schedules as schedule, i}
+					<ScheduleCard {src} on:delete={() => cardDeletion(i)} on:update={cardUpdate} {schedule} />
+				{/each}
+			</div>
+			<div class="my-auto ml-10 flex flex-col">
+				<a href="/scheduler" class="variant-filled btn-icon mx-auto block flex h-[75px] w-[75px]">
+					+
+				</a>
+				<span class="mx-auto mt-2 block">Create Schedule</span>
+			</div>
+		{:else}
+			<div class="mx-auto text-center">
+				You haven't generated a schedule yet.
+				<div class="my-auto mt-6 flex flex-col">
 					<a href="/scheduler" class="variant-filled btn-icon mx-auto block flex h-[75px] w-[75px]">
 						+
 					</a>
 					<span class="mx-auto mt-2 block">Create Schedule</span>
 				</div>
-			{/if}
-		{/await}
-	{/if}
-</div>
+			</div>
+		{/if}
+	{/await}
+{/if}

--- a/webview/src/routes/schedules/view/+page.svelte
+++ b/webview/src/routes/schedules/view/+page.svelte
@@ -30,7 +30,7 @@
 	}
 
 	if (idParam === null || idParam === '') {
-		dialog.message(`Recieved a bad query parameter for 'id' (got: ${JSON.stringify(idParam)})`);
+		dialog.message(`Received a bad query parameter for 'id' (got: ${JSON.stringify(idParam)})`);
 		history.back();
 	}
 
@@ -38,7 +38,7 @@
 
 	if (!Number.isInteger(id)) {
 		dialog.message(
-			`Recieved a bad query parameter for 'id' (got non-int: ${JSON.stringify(idParam)})`
+			`Received a bad query parameter for 'id' (got non-int: ${JSON.stringify(idParam)})`
 		);
 		history.back();
 	}


### PR DESCRIPTION
- Update `<RegionList />` cards to also display metadata about the region (field, team, and time slot count)
- Consolidate resources across the app to fit onto a single home page (`/` route)
  - Itemized these resources and numbered them in to help users figure out the order of steps needed to create a schedule
- Fixed some typos
- Fixed bug with error handling in region creation (`NameTooLong` and `NameEmpty` errors were not being caught and handled)
- Fixed bug with character escaping in popup ids in the schedule list (if a schedule was renamed to "/", for instance, its popup would never show up