### PR TITLE
112 add profile switching context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-store",
  "thiserror",
  "url",
  "urlencoding",
@@ -5814,6 +5815,18 @@ dependencies = [
  "syn 1.0.109",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin-store"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#becacf9cd615d7b5a5c4e4ed14a1379388d2348f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror",
 ]
 
 [[package]]

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -149,7 +149,14 @@ impl CreateFieldInput {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(transparent)]
-struct NameMax64(String);
+pub struct NameMax64(String);
+
+impl Deref for NameMax64 {
+    type Target = String;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CreateTeamInput {

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -101,9 +101,10 @@ pub struct CreateRegionInput {
 impl Validator for RegionName {
     type Error = RegionNameValidationError;
     fn validate(&self) -> Result<(), Self::Error> {
-        let len = self.0.len();
+        let content = self.0.trim_start_matches(char::is_whitespace).trim_end_matches(char::is_whitespace);
+        let len = content.len();
 
-        if self.0.is_empty() {
+        if content.is_empty() {
             return Err(RegionNameValidationError::EmptyName);
         }
 
@@ -168,9 +169,11 @@ pub struct CreateTeamInput {
 impl Validator for NameMax64 {
     type Error = NameMax64ValidationError;
     fn validate(&self) -> Result<(), Self::Error> {
-        let len = self.0.len();
+        let content = self.0.trim_start_matches(char::is_whitespace).trim_end_matches(char::is_whitespace);
 
-        if self.0.is_empty() {
+        let len = content.len();
+
+        if content.is_empty() {
             return Err(NameMax64ValidationError::EmptyName);
         }
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -101,7 +101,10 @@ pub struct CreateRegionInput {
 impl Validator for RegionName {
     type Error = RegionNameValidationError;
     fn validate(&self) -> Result<(), Self::Error> {
-        let content = self.0.trim_start_matches(char::is_whitespace).trim_end_matches(char::is_whitespace);
+        let content = self
+            .0
+            .trim_start_matches(char::is_whitespace)
+            .trim_end_matches(char::is_whitespace);
         let len = content.len();
 
         if content.is_empty() {
@@ -169,7 +172,10 @@ pub struct CreateTeamInput {
 impl Validator for NameMax64 {
     type Error = NameMax64ValidationError;
     fn validate(&self) -> Result<(), Self::Error> {
-        let content = self.0.trim_start_matches(char::is_whitespace).trim_end_matches(char::is_whitespace);
+        let content = self
+            .0
+            .trim_start_matches(char::is_whitespace)
+            .trim_end_matches(char::is_whitespace);
 
         let len = content.len();
 

--- a/db/src/pre_schedule_report.rs
+++ b/db/src/pre_schedule_report.rs
@@ -233,7 +233,7 @@ pub struct PreScheduleReportInput {
 
 impl PreScheduleReport {
     /// Build a PreScheduleReport from its components
-    /// 
+    ///
     /// # Parameters
     /// - `target_duplicates`: A list of bundled team & group data to guide the processor
     /// - `all_targets`: A list of all targets and extended data

--- a/db/src/pre_schedule_report.rs
+++ b/db/src/pre_schedule_report.rs
@@ -402,7 +402,7 @@ impl PreScheduleReport {
         // values have equal cardinality and sort because they are `BTreeMaps`
         let result_iterator = target_required_matches
             .into_iter()
-            .zip(target_supplied_matches.into_iter());
+            .zip(target_supplied_matches);
 
         for (required, supplied) in result_iterator {
             if required.0.target.id != supplied.0.target.id {

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -36,6 +36,7 @@ sha2 = "0.10.8"
 base64 = "0.22.1"
 httparse = "1.8.0"
 serde_urlencoded = "0.7.1"
+tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/desktop/src/bridge.rs
+++ b/desktop/src/bridge.rs
@@ -1157,7 +1157,10 @@ pub(crate) async fn create_new_profile(
         "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
     ];
 
-    if RESERVED_NAMES.contains(&name) {
+    if RESERVED_NAMES
+        .iter()
+        .any(|reserved_name| *reserved_name == name || reserved_name.to_lowercase() == name)
+    {
         return Err(CreateProfileError::IllegalNameError);
     }
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -5,155 +5,174 @@ mod auth;
 mod bridge;
 mod net;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use bridge::*;
 use db::Client;
 use futures::lock::Mutex;
 use std::sync::Arc;
-use tauri::Manager;
+use tauri::{Manager, Wry};
+use tauri_plugin_store::{Store, StoreBuilder};
 
 #[derive(Debug, Default)]
 struct SafeAppState(Arc<Mutex<State>>);
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct State {
     database: Option<Client>,
     connection_pool: Option<reqwest::Client>,
+    metadata_store: Option<Store<Wry>>,
 }
+
+pub(crate) const ACTIVE_PROFILE_BIN_KEY: &str = "active_profile";
 
 fn main() -> Result<()> {
     if dotenv::dotenv().is_err() {
         println!("Not using any environment variables in a `.env` file.")
     };
 
-    static NONE_WINDOW: Option<&'static tauri::Window> = None;
+    tauri::Builder::default()
+        .manage(SafeAppState::default())
+        .plugin(auth::init())
+        .plugin(tauri_plugin_store::Builder::default().build())
+        .setup(|app| {
+            let main_window = app.get_window("main").unwrap();
 
-    match std::panic::catch_unwind(|| {
-        tauri::Builder::default()
-            .manage(SafeAppState::default())
-            .plugin(auth::init())
-            .setup(|app| {
-                let main_window = app.get_window("main").unwrap();
+            let db_path = app
+                .path_resolver()
+                .app_data_dir()
+                .context("could not access app data directory")?;
 
-                let db_path = app
-                    .path_resolver()
-                    .app_data_dir()
-                    .context("could not access app data directory")?;
+            let dir_part = if db_path.is_file() {
+                db_path
+                    .parent()
+                    .context("path to database is not a file, and it has no parent directory")?
+            } else {
+                db_path.as_path()
+            };
 
-                let dir_part = if db_path.is_file() {
-                    db_path
-                        .parent()
-                        .expect("path to database is not a file, and it has no parent directory")
-                } else {
-                    db_path.as_path()
-                };
+            // Ensure path to database exists
+            std::fs::create_dir_all(dir_part)?;
 
-                // Ensure path to database exists
-                std::fs::create_dir_all(dir_part)?;
+            // Ensure path to profiles exists
+            let profiles_directory = dir_part.join("profiles");
+            std::fs::create_dir_all(&profiles_directory)?;
 
-                let state = app.state::<SafeAppState>();
+            let metadata_path = dir_part.join("metadata.bin");
 
-                println!("Initializing...");
+            let store = StoreBuilder::new(app.handle(), metadata_path).build();
 
-                let db_path = format!(
-                    "sqlite:{}?mode=rwc",
-                    db_path.join("data.sqlite").to_string_lossy()
-                );
-
-                println!("Using data: {db_path}");
-
-                let db_config = db::Config::new(db_path);
-
-                {
-                    let handle = tauri::async_runtime::handle();
-
-                    handle.block_on(async {
-                        let mut guard = state.0.lock().await;
-                        guard.database = Some(Client::new(&db_config).await?);
-                        guard.connection_pool = Some(reqwest::Client::new());
-                        Result::<()>::Ok(())
-                    })?;
+            let db_path = match store.get(ACTIVE_PROFILE_BIN_KEY) {
+                None => db_path,
+                Some(name_of_dir) => {
+                    let active_profile_directory = profiles_directory
+                        .join(name_of_dir.as_str().context("`name_of_dir` is not a string")?);
+                    if active_profile_directory.try_exists().context("Could not check if the profile directory exists")? {
+                        active_profile_directory
+                    } else {
+                        db_path
+                    }
                 }
+            };
 
-                println!("Done initializing.");
+            let state = app.state::<SafeAppState>();
 
-                main_window.show().unwrap();
-                Ok(())
-            })
-            .invoke_handler(tauri::generate_handler![
-                get_regions,
-                create_region,
-                delete_region,
-                load_region,
-                get_fields,
-                create_field,
-                delete_field,
-                create_team,
-                get_teams,
-                delete_team,
-                db_migrate_up_down,
-                create_group,
-                get_groups,
-                delete_group,
-                get_teams_and_tags,
-                get_time_slots,
-                create_time_slot,
-                get_field,
-                move_time_slot,
-                delete_time_slot,
-                list_reservations_between,
-                load_all_teams,
-                update_region,
-                update_team,
-                get_targets,
-                create_target,
-                delete_target,
-                target_add_group,
-                target_delete_group,
-                generate_pre_schedule_report,
-                create_reservation_type,
-                get_reservation_types,
-                delete_reservation_type,
-                update_reservation_type,
-                get_supported_concurrency_for_field,
-                update_reservation_type_concurrency_for_field,
-                get_non_default_reservation_type_concurrency_associations,
-                update_target_reservation_type,
-                generate_schedule_payload,
-                schedule,
-                get_schedules,
-                delete_schedule,
-                update_schedule,
-                get_schedule,
-                health_probe,
-                get_schedule_games,
-                get_team,
-                get_scheduler_url,
-                get_github_access_token,
-                generate_code_challenge,
-                copy_time_slots,
-                delete_time_slots_batched,
-                create_coaching_conflict,
-                delete_coaching_conflict,
-                coaching_conflict_team_op,
-                coaching_conflict_rename,
-                get_coach_conflicts,
-                get_region_metadata,
-                begin_twitter_oauth_transaction,
-                finish_twitter_oauth_transaction,
-            ])
-            .run(tauri::generate_context!())
-            .context("error while running tauri application")
-    }) {
-        Err(e) => {
-            let info = e.downcast_ref::<&str>();
-            static PANIC_MSG: &str = "unable to determine error information";
-            tauri::api::dialog::message(NONE_WINDOW, "Error", info.unwrap_or(&PANIC_MSG));
-            bail!("the app crashed in a panicked state");
-        }
-        Ok(err @ Err(..)) => err.inspect_err(|e| {
-            tauri::api::dialog::message(NONE_WINDOW, "Error", format!("{e}"));
-        }),
-        Ok(Ok(_)) => Ok(()),
-    }
+            println!("Initializing...");
+
+            let db_path = format!(
+                "sqlite:{}?mode=rwc",
+                db_path.join("data.sqlite").to_string_lossy()
+            );
+
+            println!("Using data: {db_path}");
+
+            let db_config = db::Config::new(db_path);
+
+            {
+                let handle = tauri::async_runtime::handle();
+
+                handle.block_on(async {
+                    let mut guard = state.0.lock().await;
+                    guard.database = Some(Client::new(&db_config).await.context("Could not connect to the data source. Is it missing? Please update Fieldz as soon as possible as your data may be out of sync.")?);
+                    guard.connection_pool = Some(reqwest::Client::new());
+                    guard.metadata_store = Some(store);
+                    Result::<()>::Ok(())
+                })?;
+            }
+
+            println!("Done initializing.");
+
+            main_window.show().unwrap();
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            get_regions,
+            create_region,
+            delete_region,
+            load_region,
+            get_fields,
+            create_field,
+            delete_field,
+            create_team,
+            get_teams,
+            delete_team,
+            db_migrate_up_down,
+            create_group,
+            get_groups,
+            delete_group,
+            get_teams_and_tags,
+            get_time_slots,
+            create_time_slot,
+            get_field,
+            move_time_slot,
+            delete_time_slot,
+            list_reservations_between,
+            load_all_teams,
+            update_region,
+            update_team,
+            get_targets,
+            create_target,
+            delete_target,
+            target_add_group,
+            target_delete_group,
+            generate_pre_schedule_report,
+            create_reservation_type,
+            get_reservation_types,
+            delete_reservation_type,
+            update_reservation_type,
+            get_supported_concurrency_for_field,
+            update_reservation_type_concurrency_for_field,
+            get_non_default_reservation_type_concurrency_associations,
+            update_target_reservation_type,
+            generate_schedule_payload,
+            schedule,
+            get_schedules,
+            delete_schedule,
+            update_schedule,
+            get_schedule,
+            health_probe,
+            get_schedule_games,
+            get_team,
+            get_scheduler_url,
+            get_github_access_token,
+            generate_code_challenge,
+            copy_time_slots,
+            delete_time_slots_batched,
+            create_coaching_conflict,
+            delete_coaching_conflict,
+            coaching_conflict_team_op,
+            coaching_conflict_rename,
+            get_coach_conflicts,
+            get_region_metadata,
+            begin_twitter_oauth_transaction,
+            finish_twitter_oauth_transaction,
+            list_profiles,
+            get_active_profile,
+            set_active_profile,
+            create_new_profile,
+        ])
+        .run(tauri::generate_context!())
+        .inspect_err(|e| {
+            tauri::api::dialog::blocking::message(None::<&'static tauri::Window>, "Error", format!("{e:?}"));
+        })
+        .context("error while running tauri application")
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
             let store = StoreBuilder::new(app.handle(), metadata_path).build();
 
             let db_path = match store.get(ACTIVE_PROFILE_BIN_KEY) {
-                None => db_path,
+                None | Some(serde_json::Value::Null) => db_path,
                 Some(name_of_dir) => {
                     let active_profile_directory = profiles_directory
                         .join(name_of_dir.as_str().context("`name_of_dir` is not a string")?);

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -59,9 +59,14 @@ fn main() -> Result<()> {
 
             let metadata_path = dir_part.join("metadata.bin");
 
-            let store = StoreBuilder::new(app.handle(), metadata_path).build();
+            let mut store = StoreBuilder::new(app.handle(), metadata_path).build();
+            store.load()?;
 
-            let db_path = match store.get(ACTIVE_PROFILE_BIN_KEY) {
+            let active_profile = store.get(ACTIVE_PROFILE_BIN_KEY);
+
+            println!("Last selected profile: {active_profile:?}");
+
+            let db_path = match active_profile {
                 None | Some(serde_json::Value::Null) => db_path,
                 Some(name_of_dir) => {
                     let active_profile_directory = profiles_directory
@@ -169,6 +174,8 @@ fn main() -> Result<()> {
             get_active_profile,
             set_active_profile,
             create_new_profile,
+            delete_profile,
+            rename_profile,
         ])
         .run(tauri::generate_context!())
         .inspect_err(|e| {

--- a/webview/package-lock.json
+++ b/webview/package-lock.json
@@ -11,6 +11,7 @@
 				"@floating-ui/dom": "^1.6.3",
 				"@fortawesome/free-solid-svg-icons": "^6.5.1",
 				"@tauri-apps/api": "^1.5.3",
+				"@tauri-apps/plugin-store": "^2.0.0-rc.0",
 				"firebase": "^10.11.1",
 				"svelte-fa": "^4.0.2"
 			},
@@ -1090,9 +1091,9 @@
 			}
 		},
 		"node_modules/@grpc/grpc-js": {
-			"version": "1.9.14",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.14.tgz",
-			"integrity": "sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==",
+			"version": "1.9.15",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+			"integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
 			"dependencies": {
 				"@grpc/proto-loader": "^0.7.8",
 				"@types/node": ">=12.12.47"
@@ -1751,6 +1752,28 @@
 				"url": "https://opencollective.com/tauri"
 			}
 		},
+		"node_modules/@tauri-apps/plugin-store": {
+			"version": "2.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.0.0-rc.0.tgz",
+			"integrity": "sha512-KqiEzq6EdRwxrl0/FwyNLwumDBM91xTchdu2a8vfkNub30GuP9z7RskP9ifVRI1gbxfa5TUDi0hKFk/SP7TANQ==",
+			"dependencies": {
+				"@tauri-apps/api": "^2.0.0-rc.0"
+			}
+		},
+		"node_modules/@tauri-apps/plugin-store/node_modules/@tauri-apps/api": {
+			"version": "2.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.0.0-rc.0.tgz",
+			"integrity": "sha512-v454Qs3REHc3Za59U+/eSmBsdmF+3NE5+76+lFDaitVqN4ZglDHENDaMARYKGJVZuxiSkzyqG0SeG7lLQjVkPA==",
+			"engines": {
+				"node": ">= 18.18",
+				"npm": ">= 6.6.0",
+				"yarn": ">= 1.19.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/tauri"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -2173,12 +2196,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2956,9 +2979,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"

--- a/webview/package.json
+++ b/webview/package.json
@@ -46,6 +46,7 @@
 		"@floating-ui/dom": "^1.6.3",
 		"@fortawesome/free-solid-svg-icons": "^6.5.1",
 		"@tauri-apps/api": "^1.5.3",
+		"@tauri-apps/plugin-store": "^2.0.0-rc.0",
 		"firebase": "^10.11.1",
 		"svelte-fa": "^4.0.2"
 	},

--- a/webview/src/app.pcss
+++ b/webview/src/app.pcss
@@ -7,6 +7,10 @@ html {
 	scroll-behavior: smooth;
 }
 
+body {
+	font-size: 1rem;
+}
+
 html,
 body {
 	@apply h-full overflow-hidden;

--- a/webview/src/lib/index.ts
+++ b/webview/src/lib/index.ts
@@ -180,11 +180,11 @@ export interface TargetExtension {
 
 export type RegionalUnionU64 =
 	| {
-			Interregional: number;
-	  }
+		Interregional: number;
+	}
 	| {
-			Regional: [number, number][];
-	  };
+		Regional: [number, number][];
+	};
 
 export interface DuplicateEntry {
 	team_groups: TeamGroup[];
@@ -399,4 +399,70 @@ export interface RegionMetadata {
 	team_count: number;
 	field_count: number;
 	time_slot_count: number;
+}
+
+export function handleProfileCreationError(
+	e: any,
+	toastStore: import('@skeletonlabs/skeleton').ToastStore,
+	message: typeof import('@tauri-apps/api/dialog').message
+) {
+	console.error(e);
+	if (typeof e === 'string') {
+		if (e === 'IllegalCharacterError') {
+			toastStore.trigger({
+				message: 'Profiles can only contain the following letters: a-z, A-Z, _, -, and whitespace',
+				background: 'variant-filled-error',
+				autohide: false
+			});
+			return;
+		} else if (e === 'DuplicateNameError') {
+			toastStore.trigger({
+				message: 'You already have a profile with this name!',
+				background: 'variant-filled-error',
+				autohide: false
+			});
+			return;
+		}
+	} else if (e !== null && typeof e === 'object') {
+		if ('NameTooLong' in e) {
+			if (e.NameTooLong === 'EmptyName') {
+				toastStore.trigger({
+					message: 'A profile name cannot be empty',
+					background: 'variant-filled-error',
+					autohide: false
+				});
+			} else {
+				let length: number | undefined = (<any>e.NameTooLong)?.NameTooLong?.len;
+				if (length === undefined) {
+					toastStore.trigger({
+						message: 'This name is too long',
+						background: 'variant-filled-error',
+						autohide: false
+					});
+				} else {
+					toastStore.trigger({
+						message: `This name is too long, with a length of ${length} characters. Please limit the length to 64 characters.`,
+						background: 'variant-filled-error',
+						autohide: false
+					});
+				}
+			}
+			return;
+		}
+	}
+
+	message(JSON.stringify(e), {
+		title: 'Could not create profile',
+		type: 'error'
+	});
+}
+
+const ROUTES_WITH_PROFILE_QUERY_STATE = [
+	'/region',
+	'/reservations',
+	'/schedules/view'
+];
+
+export function isRouteSafeToPersist(route: URL): boolean {
+	return !ROUTES_WITH_PROFILE_QUERY_STATE.includes(route.pathname)
 }

--- a/webview/src/lib/index.ts
+++ b/webview/src/lib/index.ts
@@ -180,11 +180,11 @@ export interface TargetExtension {
 
 export type RegionalUnionU64 =
 	| {
-		Interregional: number;
-	}
+			Interregional: number;
+	  }
 	| {
-		Regional: [number, number][];
-	};
+			Regional: [number, number][];
+	  };
 
 export interface DuplicateEntry {
 	team_groups: TeamGroup[];
@@ -422,6 +422,14 @@ export function handleProfileCreationError(
 				autohide: false
 			});
 			return;
+		} else if (e === 'IllegalNameError') {
+			toastStore.trigger({
+				message:
+					'This name might be unsafe for your file system. We are sorry, but you must pick another name.',
+				background: 'variant-filled-error',
+				autohide: false
+			});
+			return;
 		}
 	} else if (e !== null && typeof e === 'object') {
 		if ('NameTooLong' in e) {
@@ -457,12 +465,8 @@ export function handleProfileCreationError(
 	});
 }
 
-const ROUTES_WITH_PROFILE_QUERY_STATE = [
-	'/region',
-	'/reservations',
-	'/schedules/view'
-];
+const ROUTES_WITH_PROFILE_QUERY_STATE = ['/region', '/reservations', '/schedules/view'];
 
 export function isRouteSafeToPersist(route: URL): boolean {
-	return !ROUTES_WITH_PROFILE_QUERY_STATE.includes(route.pathname)
+	return !ROUTES_WITH_PROFILE_QUERY_STATE.includes(route.pathname);
 }

--- a/webview/src/lib/profileListStore.ts
+++ b/webview/src/lib/profileListStore.ts
@@ -1,0 +1,8 @@
+import { writable } from 'svelte/store';
+
+const profileList = writable<Promise<[string, { size?: number }][]>>(Promise.resolve([]));
+
+export default {
+	set: profileList.set,
+	subscribe: profileList.subscribe
+};

--- a/webview/src/lib/profileStore.ts
+++ b/webview/src/lib/profileStore.ts
@@ -1,12 +1,12 @@
-import { writable } from "svelte/store";
+import { writable } from 'svelte/store';
 
 const profileStore = writable<{
 	name: Promise<string | null>;
 }>({
-	name: new Promise(() => { })
+	name: new Promise(() => {})
 });
 
 export default {
 	subscribe: profileStore.subscribe,
-	set: profileStore.set,
-}
+	set: profileStore.set
+};

--- a/webview/src/lib/profileStore.ts
+++ b/webview/src/lib/profileStore.ts
@@ -1,0 +1,12 @@
+import { writable } from "svelte/store";
+
+const profileStore = writable<{
+	name: Promise<string | null>;
+}>({
+	name: new Promise(() => { })
+});
+
+export default {
+	subscribe: profileStore.subscribe,
+	set: profileStore.set,
+}

--- a/webview/src/routes/+layout.svelte
+++ b/webview/src/routes/+layout.svelte
@@ -261,7 +261,7 @@
 				<li><a href="/field-types">Field Types</a></li>
 				<li><a href="/scheduler">Scheduler</a></li>
 				<li><a href="/schedules">Schedules</a></li>
-				<li class="border-surface-600 border-t-2 py-1"><a href="/settings">Settings</a></li>
+				<li class="border-t-2 border-surface-600 py-1"><a href="/settings">Settings</a></li>
 			</ul>
 		</nav>
 		{#await getVersion() then version}
@@ -306,7 +306,7 @@
 			<svelte:fragment slot="trail">
 				<div class="flex items-center">
 					<div
-						class="border-surface-600 mr-8 grid grid-cols-[auto_1fr] items-center gap-4 border-r-2 p-1 pr-8"
+						class="mr-8 grid grid-cols-[auto_1fr] items-center gap-4 border-r-2 border-surface-600 p-1 pr-8"
 					>
 						<label class="contents">
 							<select bind:value={selectedProfile} on:change={switchProfile} class="select">

--- a/webview/src/routes/settings/+page.svelte
+++ b/webview/src/routes/settings/+page.svelte
@@ -1,11 +1,137 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
+	import { onMount } from 'svelte';
+	import { invoke, dialog } from '@tauri-apps/api';
+	import { listen } from '@tauri-apps/api/event';
+	import { ProgressRadial, getModalStore, getToastStore } from '@skeletonlabs/skeleton';
+	import profileStore from '$lib/profileStore';
+	import profileListStore from '$lib/profileListStore';
+	import { handleProfileCreationError } from '$lib';
+
+	let modalStore = getModalStore();
+	let toastStore = getToastStore();
+
+	function renameProfile(profileName: string) {
+		modalStore.trigger({
+			type: 'prompt',
+			title: 'Enter profile name',
+			body: `You are renaming profile ${profileName}. Give it a distinct name, with a max length of 64 characters, that uses letters, numbers, "_", "-", and spaces.`,
+			async response(r: false | string | undefined) {
+				if (!r) return;
+
+				try {
+					const newProfile = await invoke<string>('rename_profile', {
+						profileName,
+						newName: r
+					});
+
+					$profileListStore = $profileListStore.then((profileListStore) =>
+						profileListStore.map((bundle) => {
+							if (bundle[0] === profileName) {
+								bundle[0] = newProfile;
+							}
+							return bundle;
+						})
+					);
+
+					toastStore.trigger({
+						message: `Renamed profile "${profileName}" to "${newProfile}"`,
+						background: 'variant-filled-success'
+					});
+				} catch (e) {
+					handleProfileCreationError(e, toastStore, dialog.message);
+				}
+			}
+		});
+	}
+
+	function deleteProfile(profileName: string) {
+		modalStore.trigger({
+			type: 'confirm',
+			title: 'Are you sure you want to delete this profile?',
+			body: 'This action is PERMANENT and will PERMANENTLY DELETE THE DATABASE FOR THIS PROFILE. There is NO WAY TO RECOVER THIS PROFILE.',
+			response(r) {
+				if (!r) return;
+				modalStore.trigger({
+					type: 'confirm',
+					title: '⚠️⚠️ Are you REALLY, REALLY sure you want to delete this profile?',
+					body: 'Seriously. Last chance to back out. This action is PERMANENT and will PERMANENTLY DELETE THE DATABASE FOR THIS PROFILE. There is NO WAY TO RECOVER THIS PROFILE.',
+					async response(r) {
+						if (!r) return;
+						try {
+							await invoke('delete_profile', {
+								profileName
+							});
+							$profileListStore = $profileListStore.then((profiles) => {
+								return profiles.filter(([profile, _]) => profile !== profileName);
+							});
+							toastStore.trigger({
+								message: `Deleted profile: ${profileName}`,
+								background: 'variant-filled-success'
+							});
+						} catch (e) {
+							dialog.message(JSON.stringify(e), {
+								type: 'error',
+								title: 'Could not delete profile'
+							});
+						}
+					}
+				});
+			}
+		});
+	}
+
+	let profileName: string | undefined | null;
+
+	$profileStore.name.then((done) => (profileName = done));
 </script>
 
 <main in:slide={{ axis: 'x' }} out:slide={{ axis: 'x' }} class="p-4">
-	<h1 class="h2">Scheduler</h1>
+	<h1 class="h2">Settings</h1>
 
 	<button class="variant-filled btn my-4" on:click={() => history.back()}>
 		&laquo;&nbsp; Back
 	</button>
+
+	<div class="flex flex-col gap-4">
+		<section class="card p-4">
+			<h2 class="h3">Profiles</h2>
+			<p>
+				Rename and delete your custom profiles here. You may not delete the active profile or the
+				default profile.
+			</p>
+
+			<hr class="hr my-2" />
+
+			{#await $profileListStore}
+				<ProgressRadial width="w-8" />
+			{:then profiles}
+				<ul class="flex flex-col gap-8 sm:flex-row">
+					{#each profiles ?? [] as [profile, metadata]}
+						<li class="mx-4 my-4 flex flex-col gap-4">
+							<header>
+								{profile} &mdash; {metadata.size ?? 0} bytes
+							</header>
+							<div class="grid grid-cols-2">
+								<button
+									class="variant-filled btn"
+									disabled={profileName === profile}
+									on:click={() => renameProfile(profile)}>Rename</button
+								>
+								<button
+									class="variant-filled btn"
+									disabled={profileName === profile}
+									on:click={() => deleteProfile(profile)}>Delete</button
+								>
+							</div>
+						</li>
+					{:else}
+						<li>You haven't created any custom profiles</li>
+					{/each}
+				</ul>
+			{:catch}
+				Could not load profiles.
+			{/await}
+		</section>
+	</div>
 </main>


### PR DESCRIPTION
Fixes #112 

### Changes
- Adds the ability to switch between profiles, where each profile has its own unique database
- New UI and settings page
- Show a dialog message on failed startup runs to avoid the case where an error in the `setup` handler crashes the app without any indicator or log message.