### PR TITLE
129 cannot schedule games when practice time slots exist without a target for practices

### DIFF
--- a/backend/src/algorithm/practices.rs
+++ b/backend/src/algorithm/practices.rs
@@ -297,7 +297,7 @@ where
      * result in nearly all proposed moves being accepted, regardless of whether they improve the
      * solution or not. This can lead to inefficient exploration.
      */
-    let temperature = time_slots_len.clamp(1.0, time_slots_len * 1.2);
+    let temperature = time_slots_len.clamp(1.0, time_slots_len.max(1.) * 1.2);
 
     println!("Solving practices (i={max_iters}, temperature={temperature} degrees)");
 

--- a/backend/src/algorithm/v1.rs
+++ b/backend/src/algorithm/v1.rs
@@ -5,8 +5,6 @@ use petgraph::{
     graphmap::{DiGraphMap, GraphMap},
     Directed,
 };
-use rand::{rngs::ThreadRng, Rng};
-
 use std::{
     cell::Cell,
     cmp::Ordering,
@@ -43,23 +41,6 @@ impl ScheduledOutput {
     pub fn unplayed_matches(&self) -> &[Game] {
         &self.unplayed_matches
     }
-}
-
-struct RandomEdgeSupplier<'a> {
-    vec: Vec<(Pin<&'a Team>, Pin<&'a Team>, &'a Option<&'a Reservation>)>,
-    rng: ThreadRng,
-}
-
-impl<'a> Iterator for RandomEdgeSupplier<'a> {
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.vec.is_empty() {
-            return None;
-        }
-
-        let index = self.rng.gen_range(0..self.vec.len());
-        Some(self.vec.swap_remove(index))
-    }
-    type Item = (Pin<&'a Team>, Pin<&'a Team>, &'a Option<&'a Reservation>);
 }
 
 impl League {

--- a/desktop/src/bridge.rs
+++ b/desktop/src/bridge.rs
@@ -516,6 +516,7 @@ pub(crate) async fn generate_pre_schedule_report(
 #[tauri::command]
 pub(crate) async fn get_reservation_types(
     app: AppHandle,
+    ids: Option<Vec<i32>>,
 ) -> Result<Vec<db::reservation_type::Model>, String> {
     let state = app.state::<SafeAppState>();
     let lock = state.0.lock().await;
@@ -525,7 +526,7 @@ pub(crate) async fn get_reservation_types(
         .ok_or("database was not initialized".to_owned())?;
 
     client
-        .get_reservation_types()
+        .get_reservation_types(ids)
         .await
         .map_err(|e| format!("{}:{} {e}", file!(), line!()))
 }

--- a/desktop/src/net.rs
+++ b/desktop/src/net.rs
@@ -140,6 +140,9 @@ where
     let response = client
         .schedule(request)
         .await
+        .inspect_err(|e| {
+            eprintln!("{e:?} {}:{}", line!(), column!());
+        })
         .map_err(|e| ScheduleRequestError::RPCError(e.to_string()))?;
 
     let mut inbound = response.into_inner();
@@ -208,12 +211,14 @@ macro_rules! env_function {
                 return Ok(var);
             }
 
+            let value = std::env::var($var).map(Cow::Owned);
+
             println!(
-                "Warning: using runtime environment variable: {}",
+                "Warning: using runtime environment variable: {} = {value:?}",
                 stringify!($var)
             );
 
-            std::env::var($var).map(Cow::Owned)
+            value
         }
     };
 }

--- a/gcloud/grpc_server/src/lib.rs
+++ b/gcloud/grpc_server/src/lib.rs
@@ -33,6 +33,7 @@ pub struct SchedulerUsage {
 pub(crate) async fn signal_usage(
     user_id: String,
 ) -> Result<SchedulerUsage, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    
     let usage_endpoint = std::env::var("QUOTA_SERVER_URL").unwrap();
 
     let response = reqwest::get(format!("{usage_endpoint}?uid={user_id}"))


### PR DESCRIPTION
- Remove `panic!` in backend caused by scheduling games when a practice field type exists without a practice target or practice time slots laid down (afb2318c29126bb984644b7b30fab3aa36bd0f70)
- Remove additional UI error preventing target creation for max 1 game schedule, 1 practice schedule, which should be allowed.
  - Allowed: `Games(u8, girls)`, `Practices(u8, girls)`
  - Not Allowed: `Games(u8, girls)`, `Games(u8, girls)` OR `Practices(u8, girls)`, `Practices(u8, girls)`